### PR TITLE
デフォルトリージョンをus-east-1に変更

### DIFF
--- a/aws_cli/.env.example
+++ b/aws_cli/.env.example
@@ -1,3 +1,3 @@
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
-AWS_DEFAULT_REGION=ap-northeast-1
+AWS_DEFAULT_REGION=us-east-1

--- a/aws_cli/README.md
+++ b/aws_cli/README.md
@@ -27,7 +27,7 @@ cp .env.example .env
 ```
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
-AWS_DEFAULT_REGION=ap-northeast-1
+AWS_DEFAULT_REGION=us-east-1
 ```
 
 ※ `.env`ファイルはGitにコミットしないでください（`.gitignore`に追加済み）
@@ -85,7 +85,7 @@ chmod +x deploy.sh
 3. Lambda関数の作成または更新
    - 関数名: `lambda-deploy-test-cli`
    - ランタイム: Python 3.12
-   - リージョン: ap-northeast-1
+   - リージョン: .envで指定したリージョン（デフォルト: us-east-1）
 
 ## 動作確認
 
@@ -93,7 +93,7 @@ chmod +x deploy.sh
 
 ### マネジメントコンソールでテスト
 
-1. [Lambda コンソール](https://ap-northeast-1.console.aws.amazon.com/lambda/home?region=ap-northeast-1#/functions/lambda-deploy-test-cli)にアクセス
+1. デプロイ完了時に表示されるLambdaコンソールのURLにアクセス
 
 2. 「テスト」タブを開く
 
@@ -111,7 +111,7 @@ chmod +x deploy.sh
 ```bash
 aws lambda invoke \
   --function-name lambda-deploy-test-cli \
-  --region ap-northeast-1 \
+  --region us-east-1 \
   --payload '{}' \
   response.json
 

--- a/aws_cli/cleanup.sh
+++ b/aws_cli/cleanup.sh
@@ -7,7 +7,7 @@ set -e
 # 設定
 FUNCTION_NAME="lambda-deploy-test-cli"
 ROLE_NAME="lambda-deploy-test-role"
-REGION="ap-northeast-1"
+REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 
 echo "=== Lambda関数クリーンアップスクリプト (AWS CLI) ==="
 

--- a/aws_cli/deploy.sh
+++ b/aws_cli/deploy.sh
@@ -7,7 +7,7 @@ set -e
 # 設定
 FUNCTION_NAME="lambda-deploy-test-cli"
 ROLE_NAME="lambda-deploy-test-role"
-REGION="ap-northeast-1"
+REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 RUNTIME="python3.12"
 HANDLER="lambda_function.lambda_handler"
 
@@ -113,4 +113,4 @@ echo "関数名: $FUNCTION_NAME"
 echo "リージョン: $REGION"
 echo ""
 echo "マネジメントコンソールでテストしてください："
-echo "https://ap-northeast-1.console.aws.amazon.com/lambda/home?region=ap-northeast-1#/functions/$FUNCTION_NAME"
+echo "https://${REGION}.console.aws.amazon.com/lambda/home?region=${REGION}#/functions/$FUNCTION_NAME"


### PR DESCRIPTION
## Summary
- デフォルトリージョンを`ap-northeast-1`から`us-east-1`に変更
- スクリプトで`.env`の`AWS_DEFAULT_REGION`環境変数を使用するように修正

## 変更内容
- `aws_cli/.env.example`: デフォルトリージョンをus-east-1に変更
- `aws_cli/deploy.sh`: `REGION`変数を環境変数から取得するように変更
- `aws_cli/cleanup.sh`: `REGION`変数を環境変数から取得するように変更
- `aws_cli/README.md`: リージョン記載を更新

## Test plan
- [ ] deploy.shでLambda関数がus-east-1にデプロイされることを確認
- [ ] .envでリージョンを変更した場合、指定したリージョンにデプロイされることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)