### PR TITLE
aws_cliに.gitignoreを追加してpackageディレクトリを除外

### DIFF
--- a/aws_cli/.gitignore
+++ b/aws_cli/.gitignore
@@ -1,0 +1,1 @@
+package/


### PR DESCRIPTION
## Summary
- `aws_cli/`ディレクトリに`.gitignore`を追加
- デプロイ時に生成される`package/`ディレクトリを除外

## 変更内容
- `aws_cli/.gitignore`を新規作成

## Test plan
- [ ] `deploy.sh`実行後、`package/`ディレクトリがgit statusに表示されないことを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)