### PR TITLE
Lambda Inspectorのレイヤー対応版を追加

### DIFF
--- a/lambda_inspector_layer/.env.example
+++ b/lambda_inspector_layer/.env.example
@@ -1,0 +1,3 @@
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret-key
+AWS_DEFAULT_REGION=us-east-1

--- a/lambda_inspector_layer/.gitignore
+++ b/lambda_inspector_layer/.gitignore
@@ -1,0 +1,3 @@
+lambda_function.zip
+lambda_code/
+layers/

--- a/lambda_inspector_layer/Dockerfile
+++ b/lambda_inspector_layer/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# 必要なパッケージをインストール
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# AWS CLI v2をインストール
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
+
+# 作業用のディレクトリをマウントポイントとして使用
+VOLUME /app
+
+# デフォルトコマンド
+CMD ["/bin/bash"]

--- a/lambda_inspector_layer/README.md
+++ b/lambda_inspector_layer/README.md
@@ -1,0 +1,160 @@
+# Lambda Inspector（レイヤー対応版）
+
+デプロイ済みのLambda関数とそのレイヤーをダウンロードし、インストールされているライブラリを確認するためのツールです。
+
+## 概要
+
+このディレクトリには、Lambda関数とレイヤーのコードをダウンロードして検査するための以下のファイルが含まれています：
+
+- `Dockerfile` - 実行環境用のDockerイメージ
+- `inspect.sh` - ダウンロード・検査スクリプト（レイヤー対応）
+- `list_packages.py` - ライブラリ一覧表示スクリプト
+
+## lambda_inspector/との違い
+
+| 項目 | lambda_inspector/ | lambda_inspector_layer/ |
+|------|-------------------|-------------------------|
+| 関数コード | ダウンロード可 | ダウンロード可 |
+| レイヤー | 非対応 | 対応 |
+| ライブラリ確認 | 関数内のみ | 関数＋レイヤー |
+
+## 前提条件
+
+### AWS認証情報
+
+`.env`ファイルを作成してAWS認証情報を設定してください：
+
+```bash
+cp .env.example .env
+```
+
+`.env`ファイルを編集して認証情報を入力：
+
+```
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret-key
+AWS_DEFAULT_REGION=us-east-1
+```
+
+※ `.env`ファイルはGitにコミットしないでください（`.gitignore`に追加済み）
+
+### 必要な権限
+
+使用するIAMユーザーには以下の権限が必要です：
+
+- Lambda関数の読み取り権限（`lambda:GetFunction`）
+- Lambdaレイヤーの読み取り権限（`lambda:GetLayerVersion`）
+
+## 使用方法
+
+### 1. Dockerイメージをビルド
+
+```bash
+docker build -t lambda-inspector-layer .
+```
+
+### 2. 検査対象の関数名を設定
+
+```bash
+FUNCTION_NAME=your-lambda-function-name
+```
+
+### 3. コンテナを起動して検査を実行
+
+```bash
+docker run --rm \
+  -v $(pwd):/app \
+  --env-file .env \
+  -e AWS_PAGER= \
+  -e FUNCTION_NAME=${FUNCTION_NAME} \
+  lambda-inspector-layer \
+  bash -c "chmod +x inspect.sh && ./inspect.sh"
+```
+
+## 出力例
+
+### レイヤーを使用している関数の場合
+
+```
+=== Lambda関数の検査（レイヤー対応版）: lambda-deploy-test-cli-layer ===
+=== Lambda関数の情報を取得中 ===
+=== Lambda関数のコードをダウンロード ===
+=== Lambda関数のコードを展開 ===
+=== レイヤー情報を取得中 ===
+使用されているレイヤー:
+  - arn:aws:lambda:us-east-1:123456789012:layer:my-layer:1
+    ダウンロード中...
+    展開中...
+
+=== インストールされているライブラリ ===
+requests==2.31.0
+urllib3==2.0.4
+charset-normalizer==3.2.0
+certifi==2023.7.22
+idna==3.4
+
+=== 検査完了 ===
+関数コード: lambda_code/
+レイヤー: layers/
+```
+
+### レイヤーを使用していない関数の場合
+
+```
+=== Lambda関数の検査（レイヤー対応版）: lambda-deploy-test-cli ===
+=== Lambda関数の情報を取得中 ===
+=== Lambda関数のコードをダウンロード ===
+=== Lambda関数のコードを展開 ===
+=== レイヤー情報を取得中 ===
+レイヤーは使用されていません。
+
+=== インストールされているライブラリ ===
+requests==2.31.0
+...
+
+=== 検査完了 ===
+関数コード: lambda_code/
+```
+
+## ファイル構成
+
+```
+lambda_inspector_layer/
+├── .env.example          # 環境変数のサンプル
+├── .gitignore            # 成果物の除外
+├── Dockerfile            # 実行環境用Dockerイメージ
+├── README.md             # このファイル
+├── inspect.sh            # ダウンロード・検査スクリプト（レイヤー対応）
+└── list_packages.py      # ライブラリ一覧表示スクリプト
+```
+
+## 検査後の成果物
+
+実行後、以下のファイル・ディレクトリが作成されます：
+
+- `lambda_function.zip` - ダウンロードしたLambda関数のZIPファイル
+- `lambda_code/` - 展開されたLambda関数のコード
+- `layers/` - 展開されたレイヤーのコード（レイヤーがある場合）
+  - `layer_1/` - 1つ目のレイヤー
+  - `layer_2/` - 2つ目のレイヤー（複数ある場合）
+  - ...
+
+これらを直接確認することで、Lambda関数とレイヤーの詳細な内容を調査できます。
+
+## トラブルシューティング
+
+### AccessDeniedエラー
+
+Lambda関数またはレイヤーへのアクセス権限がない場合に発生します。IAMユーザーに以下の権限があることを確認してください：
+- `lambda:GetFunction`
+- `lambda:GetLayerVersion`
+
+### 関数が見つからない
+
+- 関数名が正しいか確認してください
+- リージョンが正しいか確認してください（`.env`の`AWS_DEFAULT_REGION`）
+
+### レイヤーのライブラリが表示されない
+
+- レイヤーが`python/`ディレクトリ構造でパッケージされているか確認してください
+- Lambda関数とレイヤーのPythonランタイムバージョンが一致しているか確認してください

--- a/lambda_inspector_layer/inspect.sh
+++ b/lambda_inspector_layer/inspect.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+# 変数の確認
+if [ -z "$FUNCTION_NAME" ]; then
+  echo "エラー: FUNCTION_NAME環境変数を設定してください"
+  exit 1
+fi
+
+REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+echo "=== Lambda関数の検査（レイヤー対応版）: ${FUNCTION_NAME} ==="
+
+# 既存のディレクトリをクリーンアップ
+rm -rf lambda_code/
+rm -rf layers/
+rm -f lambda_function.zip
+
+# Lambda関数の情報を取得
+echo "=== Lambda関数の情報を取得中 ==="
+FUNCTION_INFO=$(aws lambda get-function --function-name ${FUNCTION_NAME} --region ${REGION})
+
+# Lambda関数のコードをダウンロード
+echo "=== Lambda関数のコードをダウンロード ==="
+CODE_URL=$(echo "$FUNCTION_INFO" | grep -o '"Location": "[^"]*"' | head -1 | cut -d'"' -f4)
+curl -s -o lambda_function.zip "$CODE_URL"
+
+# ZIPを展開
+echo "=== Lambda関数のコードを展開 ==="
+mkdir -p lambda_code
+unzip -q lambda_function.zip -d lambda_code/
+
+# レイヤー情報を取得
+echo "=== レイヤー情報を取得中 ==="
+LAYER_ARNS=$(aws lambda get-function --function-name ${FUNCTION_NAME} --region ${REGION} \
+  --query 'Configuration.Layers[].Arn' --output text 2>/dev/null || echo "")
+
+if [ -z "$LAYER_ARNS" ] || [ "$LAYER_ARNS" = "None" ]; then
+  echo "レイヤーは使用されていません。"
+else
+  echo "使用されているレイヤー:"
+  mkdir -p layers
+
+  LAYER_NUM=1
+  for LAYER_ARN in $LAYER_ARNS; do
+    echo "  - $LAYER_ARN"
+
+    # レイヤーのコードをダウンロード
+    echo "    ダウンロード中..."
+    LAYER_URL=$(aws lambda get-layer-version-by-arn --arn "$LAYER_ARN" --region ${REGION} \
+      --query 'Content.Location' --output text)
+
+    LAYER_ZIP="layers/layer_${LAYER_NUM}.zip"
+    LAYER_DIR="layers/layer_${LAYER_NUM}"
+
+    curl -s -o "$LAYER_ZIP" "$LAYER_URL"
+
+    # レイヤーを展開
+    echo "    展開中..."
+    mkdir -p "$LAYER_DIR"
+    unzip -q "$LAYER_ZIP" -d "$LAYER_DIR"
+
+    LAYER_NUM=$((LAYER_NUM + 1))
+  done
+fi
+
+# PYTHONPATHを構築（lambda_code + 各レイヤーのpythonディレクトリ）
+PYTHON_PATHS="lambda_code"
+
+if [ -d "layers" ]; then
+  for LAYER_DIR in layers/layer_*/; do
+    if [ -d "${LAYER_DIR}python" ]; then
+      PYTHON_PATHS="${PYTHON_PATHS}:${LAYER_DIR}python"
+    fi
+    # レイヤー直下にパッケージがある場合も追加
+    if [ -d "$LAYER_DIR" ]; then
+      PYTHON_PATHS="${PYTHON_PATHS}:${LAYER_DIR}"
+    fi
+  done
+fi
+
+echo ""
+echo "=== インストールされているライブラリ ==="
+PYTHONPATH="$PYTHON_PATHS" python list_packages.py
+
+echo ""
+echo "=== 検査完了 ==="
+echo "関数コード: lambda_code/"
+if [ -d "layers" ]; then
+  echo "レイヤー: layers/"
+fi

--- a/lambda_inspector_layer/list_packages.py
+++ b/lambda_inspector_layer/list_packages.py
@@ -1,0 +1,4 @@
+from importlib.metadata import distributions
+
+for d in distributions():
+    print(f'{d.metadata["Name"]}=={d.version}')


### PR DESCRIPTION
## Summary
- Lambda関数に紐づくレイヤーも含めてライブラリを確認できるレイヤー対応版を追加
- `lambda_inspector_layer/`ディレクトリを新規作成

## lambda_inspector/との違い
| 項目 | lambda_inspector/ | lambda_inspector_layer/ |
|------|-------------------|-------------------------|
| 関数コード | ダウンロード可 | ダウンロード可 |
| レイヤー | 非対応 | 対応 |
| ライブラリ確認 | 関数内のみ | 関数＋レイヤー |

## 変更内容
- `lambda_inspector_layer/Dockerfile` - 実行環境用Dockerイメージ
- `lambda_inspector_layer/inspect.sh` - ダウンロード・検査スクリプト（レイヤー対応）
- `lambda_inspector_layer/list_packages.py` - ライブラリ一覧表示スクリプト
- `lambda_inspector_layer/README.md` - 手順書
- `lambda_inspector_layer/.env.example` - 環境変数サンプル
- `lambda_inspector_layer/.gitignore` - 成果物の除外

## Test plan
- [ ] Dockerイメージのビルド確認
- [ ] レイヤーを使用しているLambda関数でinspect.shを実行し、レイヤー内のライブラリも表示されることを確認
- [ ] レイヤーを使用していないLambda関数でも正常に動作することを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)